### PR TITLE
Allow Robots to rotate 90 degrees to the left

### DIFF
--- a/lib/cli_driver.rb
+++ b/lib/cli_driver.rb
@@ -17,6 +17,7 @@ class CLIDriver
     p report if command == 'REPORT'
     move if command == 'MOVE'
     right if command == 'RIGHT'
+    left if command == 'LEFT'
   end
 
   private
@@ -44,6 +45,10 @@ class CLIDriver
 
   def right
     @robot.right
+  end
+
+  def left
+    @robot.left
   end
 
   def report

--- a/lib/direction.rb
+++ b/lib/direction.rb
@@ -6,6 +6,8 @@ class Direction
   Y_MOVE = 0
 
   def self.right; end
+
+  def self.left; end
 end
 
 # Robot is facing north.
@@ -14,6 +16,10 @@ class North < Direction
 
   def self.right
     East
+  end
+
+  def self.left
+    West
   end
 end
 
@@ -24,6 +30,10 @@ class South < Direction
   def self.right
     West
   end
+
+  def self.left
+    East
+  end
 end
 
 # Robot is facing east.
@@ -33,6 +43,10 @@ class East < Direction
   def self.right
     South
   end
+
+  def self.left
+    North
+  end
 end
 
 # Robot is facing west.
@@ -41,5 +55,9 @@ class West < Direction
 
   def self.right
     North
+  end
+
+  def self.left
+    South
   end
 end

--- a/lib/robot.rb
+++ b/lib/robot.rb
@@ -36,4 +36,10 @@ class Robot
 
     @direction = direction.right
   end
+
+  def left
+    return unless placed?
+
+    @direction = direction.left
+  end
 end

--- a/spec/cli_driver_spec.rb
+++ b/spec/cli_driver_spec.rb
@@ -38,7 +38,14 @@ RSpec.describe CLIDriver do
       end
     end
 
-    context 'when command is LEFT'
+    context 'when command is LEFT' do
+      it 'calls left on the robot' do
+        driver.parse('LEFT')
+
+        expect(robot).to have_received(:left)
+      end
+    end
+
     context 'when command is RIGHT' do
       it 'calls right on the robot' do
         driver.parse('RIGHT')

--- a/spec/direction_spec.rb
+++ b/spec/direction_spec.rb
@@ -7,12 +7,24 @@ RSpec.describe North do
       expect(described_class.right).to eq(East)
     end
   end
+
+  describe '.left' do
+    it 'returns a new West direction' do
+      expect(described_class.left).to eq(West)
+    end
+  end
 end
 
 RSpec.describe East do
   describe '.right' do
     it 'returns a new South direction' do
       expect(described_class.right).to eq(South)
+    end
+  end
+
+  describe '.left' do
+    it 'returns a new North direction' do
+      expect(described_class.left).to eq(North)
     end
   end
 end
@@ -23,12 +35,24 @@ RSpec.describe South do
       expect(described_class.right).to eq(West)
     end
   end
+
+  describe '.left' do
+    it 'returns a new East direction' do
+      expect(described_class.left).to eq(East)
+    end
+  end
 end
 
 RSpec.describe West do
   describe '.right' do
     it 'returns a new North direction' do
       expect(described_class.right).to eq(North)
+    end
+  end
+
+  describe '.left' do
+    it 'returns a new South direction' do
+      expect(described_class.left).to eq(South)
     end
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -21,5 +21,11 @@ RSpec.describe 'Integration' do
     driver.parse('RIGHT')
     expect { driver.parse('REPORT') }.to output(/0,0,EAST/).to_stdout
   end
+
+  it 'returns Example b' do
+    driver.parse('PLACE 0,0,NORTH')
+    driver.parse('LEFT')
+    expect { driver.parse('REPORT') }.to output(/0,0,WEST/).to_stdout
+  end
 end
 # rubocop:enable RSpec/DescribeClass

--- a/spec/robot_spec.rb
+++ b/spec/robot_spec.rb
@@ -133,6 +133,21 @@ RSpec.describe Robot do
         expect { robot.right }.to change(robot, :direction).to(new_direction)
       end
     end
+
+    describe '#left' do
+      it 'calls left on the direction' do
+        robot.left
+
+        expect(direction).to have_received(:left)
+      end
+
+      it 'changes the direction' do
+        new_direction = double
+        allow(direction).to receive(:left).and_return(new_direction)
+
+        expect { robot.left }.to change(robot, :direction).to(new_direction)
+      end
+    end
   end
 
   context 'when the robot has not been placed' do
@@ -159,12 +174,11 @@ RSpec.describe Robot do
         expect { robot.right }.not_to change(robot, :direction)
       end
     end
-  end
 
-  describe '#left' do
-    it 'rotates the robot 90 degrees left'
-    context 'when robot has not been placed' do
-      it 'ignores the command'
+    describe '#left' do
+      it 'ignores the command' do
+        expect { robot.left }.not_to change(robot, :direction)
+      end
     end
   end
 end


### PR DESCRIPTION
- Add to CLIDriver, Direction and Robot classes.
- Add specs for all.
- Add integration spec.

Fixes #2.